### PR TITLE
Modular Curve Framework

### DIFF
--- a/code/globalincs/type_traits.h
+++ b/code/globalincs/type_traits.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <optional>
+#include <tl/optional.hpp>
+
+template <typename T> struct is_optional : std::false_type {};
+template<typename T> struct is_optional<std::optional<T>> : std::true_type {};
+template<> 			 struct is_optional<std::nullopt_t> : std::true_type {};
+template<typename T> struct is_optional<tl::optional<T>> : std::true_type {};
+template<> 			 struct is_optional<tl::nullopt_t> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_optional_v = is_optional<T>::value;
+
+template <typename T> struct is_tuple : std::false_type {};
+template <typename... U> struct is_tuple<std::tuple <U...>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_tuple_v = is_tuple<T>::value;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -92,17 +92,16 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 		damage = wip->damage;
 	}
 
-	if (wip->damage_incidence_max != 1.0f || wip->damage_incidence_min != 1.0f) {
-		float dot = -vm_vec_dot(&weapon_obj->orient.vec.fvec, &worldNormal);
+	float dot = -vm_vec_dot(&weapon_obj->orient.vec.fvec, &worldNormal);
 
+	if (wip->damage_incidence_max != 1.0f || wip->damage_incidence_min != 1.0f) {
 		if (dot < 0.0f)
 			dot = 0.0f;
 
 		damage *= wip->damage_incidence_min + ((wip->damage_incidence_max - wip->damage_incidence_min) * dot);
 	}
 
-	if (wip->damage_curve_idx >= 0)
-		damage *= Curves[wip->damage_curve_idx].GetValue(f2fl(Missiontime - wp->creation_time) / wip->lifetime);
+	damage *= wip->hit_modular_curves.get_output(weapon_info::HitModularCurveOutputs::DAMAGE_MULT, std::forward_as_tuple(*wp, *pship_obj, dot), &wp->modular_curves_instance);
 
 	// if this is friendly fire, we check for the friendly fire cap values
 	if (wp->team == shipp->team) {

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -40,9 +40,11 @@ int collide_weapon_weapon( obj_pair * pair )
 	if (A->parent_sig == B->parent_sig)
 		return 1;
 
+	float dot = vm_vec_dot(&A->orient.vec.fvec, &B->orient.vec.fvec);
+
 	//	Only shoot down teammate's missile if not traveling in nearly same direction.
 	if (Weapons[A->instance].team == Weapons[B->instance].team)
-		if (vm_vec_dot(&A->orient.vec.fvec, &B->orient.vec.fvec) > 0.7f)
+		if (dot > 0.7f)
 			return 1;
 
 	//	Ignore collisions involving a bomb if the bomb is not yet armed.
@@ -120,15 +122,14 @@ int collide_weapon_weapon( obj_pair * pair )
 		// damage calculation should not be done on clients, the server will tell the client version of the bomb when to die
 		if(!a_override && !b_override && !MULTIPLAYER_CLIENT)
 		{
+			float dot_curve = -dot;
 			float aDamage = wipA->damage;
-			if (wipA->damage_curve_idx >= 0)
-				aDamage *= Curves[wipA->damage_curve_idx].GetValue(A_time_alive / wipA->lifetime);
+			aDamage *= wipA->hit_modular_curves.get_output(weapon_info::HitModularCurveOutputs::DAMAGE_MULT, std::forward_as_tuple(*wpA, *B, dot_curve), &wpA->modular_curves_instance);
 			if (wipB->armor_type_idx >= 0)
 				aDamage = Armor_types[wipB->armor_type_idx].GetDamage(aDamage, wipA->damage_type_idx, 1.0f, false);
 
 			float bDamage = wipB->damage;
-			if (wipB->damage_curve_idx >= 0)
-				bDamage *= Curves[wipB->damage_curve_idx].GetValue(B_time_alive / wipB->lifetime);
+			bDamage *= wipB->hit_modular_curves.get_output(weapon_info::HitModularCurveOutputs::DAMAGE_MULT, std::forward_as_tuple(*wpB, *A, dot_curve), &wpB->modular_curves_instance);
 			if (wipA->armor_type_idx >= 0)
 				bDamage = Armor_types[wipA->armor_type_idx].GetDamage(bDamage, wipB->damage_type_idx, 1.0f, false);
 

--- a/code/parse/encrypt.cpp
+++ b/code/parse/encrypt.cpp
@@ -472,14 +472,5 @@ uint32_t hash_fnv1a(const SCP_string& string) {
 }
 
 uint32_t hash_fnv1a(const void* data, size_t length) {
-	const uint32_t fnv1a_magic_prime = 16777619;
-	uint32_t hash = 2166136261;
-
-	auto bytes = reinterpret_cast<const uint8_t*>(data);
-
-	for (size_t cnt = 0; cnt < length; cnt++) {
-		hash = (hash ^ bytes[cnt]) * fnv1a_magic_prime;
-	}
-
-	return hash;
+	return hash_fnv1a(reinterpret_cast<const uint8_t*>(data), length);
 }

--- a/code/parse/encrypt.h
+++ b/code/parse/encrypt.h
@@ -32,8 +32,26 @@ void encrypt(char *text, int text_len, char *scrambled_text, int *scrambled_len,
 void unencrypt(char *scrambled_text, int scrambled_len, char *text, int *text_len);
 
 //A fast platform/std-implementation stable hashing algorithm. Implements the FNV-1a hash algorithm
+constexpr uint32_t hash_fnv1a(const uint8_t* bytes, size_t length) {
+	const uint32_t fnv1a_magic_prime = 16777619;
+	uint32_t hash = 2166136261;
+
+	for (size_t cnt = 0; cnt < length; cnt++) {
+		hash = (hash ^ bytes[cnt]) * fnv1a_magic_prime;
+	}
+
+	return hash;
+}
+
 uint32_t hash_fnv1a(const SCP_string& string);
 uint32_t hash_fnv1a(const void* data, size_t length);
+constexpr uint32_t hash_fnv1a(uint32_t value) {
+	uint8_t bytes[4] = {static_cast<uint8_t>((value) & 0xff),
+						static_cast<uint8_t>((value >> 8) & 0xff),
+						static_cast<uint8_t>((value >> 16) & 0xff),
+						static_cast<uint8_t>((value >> 24) & 0xff)};
+	return hash_fnv1a(bytes, sizeof(uint32_t));
+}
 
 #endif
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -400,6 +400,7 @@ add_file_folder("GlobalIncs"
 	globalincs/systemvars.cpp
 	globalincs/systemvars.h
 	globalincs/toolchain.h
+	globalincs/type_traits.h
 	globalincs/undosys.cpp
 	globalincs/undosys.h
 	globalincs/utility.h

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1668,6 +1668,7 @@ add_file_folder("Utils"
 	utils/HeapAllocator.h
 	utils/id.h
 	utils/join_string.h
+	utils/modular_curves.h
 	utils/Random.cpp
 	utils/Random.h
 	utils/RandomRange.h

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -134,6 +134,13 @@ class RandomRange {
 	{
 		return m_maxValue;
 	}
+
+	void seed(typename GeneratorType::result_type new_seed) const {
+		if (m_constant)
+			return;
+
+		m_generator.seed(new_seed);
+	}
 };
 
 /**
@@ -528,7 +535,15 @@ class ParsedRandomRange {
 			return range.max();
 		}
 	};
-	
+
+	struct seed_helper {
+		unsigned int new_seed;
+
+		template <typename T>
+		inline void operator()(T& range) {
+			range.seed(new_seed);
+		}
+	};
 
   public:
 	  template<typename T>
@@ -547,6 +562,9 @@ class ParsedRandomRange {
 	}
 	inline result_type max() const {
 		return static_cast<result_type>(mpark::visit(max_helper{}, m_random_range));
+	}
+	inline void seed(unsigned int new_seed) const {
+		mpark::visit(seed_helper{new_seed}, m_random_range);
 	}
 	static ParsedRandomRange parseRandomRange(float min = std::numeric_limits<float>::lowest()/2.1f, float max = std::numeric_limits<float>::max()/2.1f) {
 		switch (optional_string_either("NORMAL", "CURVE")) {

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -15,11 +15,19 @@ template<> 			 constexpr bool is_optional<std::nullopt_t> = true;
 template <typename T> struct is_tuple : std::false_type {};
 template <typename... U> struct is_tuple<std::tuple <U...>> : std::true_type {};
 
+//
+// Modular Curve Input Grabbers
+//
+// These structs help at building accessors to potential inputs for modular curve definitions
+// modular_curves_submember_input -> provides a fully inlineable and compiletime-defined way to access class members, members-of-members, and index into global arrays
+// modular_curves_functional_input -> provides an interface for grabbing floats from arbitrary functions. Not as well optimizable as the above, and not declarable inline (until C++20)
+//
+
 template<auto... grabbers>
 struct modular_curves_submember_input {
   private:
 	template<typename input_type, auto grabber>
-	inline auto grab_part(const input_type& input) const {
+	static inline auto grab_part(const input_type& input) {
 		//Pointer to member type, i.e. for submember access
 		if constexpr (std::is_member_object_pointer_v<decltype(grabber)>) {
 			if constexpr (std::is_pointer_v<std::remove_reference_t<input_type>>)
@@ -49,7 +57,7 @@ struct modular_curves_submember_input {
 	}
 
 	template<typename input_type, auto grabber, auto... other_grabbers>
-	inline auto grab_internal(std::reference_wrapper<const input_type> input) const {
+	static inline auto grab_internal(std::reference_wrapper<const input_type> input) {
 		//If we're down to one grabber only, return it
 		if constexpr (sizeof...(other_grabbers) == 0){
 			return grab_part<input_type, grabber>(input.get());
@@ -82,7 +90,7 @@ struct modular_curves_submember_input {
 	}
 
 	template<int tuple_idx, typename input_type>
-	inline auto grab_from_tuple(const input_type& input) const {
+	static inline auto grab_from_tuple(const input_type& input) {
 		if constexpr(tuple_idx < 0)
 			return std::cref(input);
 		else
@@ -91,7 +99,7 @@ struct modular_curves_submember_input {
 
   public:
 	template<int tuple_idx, typename input_type>
-	inline float grab(const input_type& input) const {
+	static inline float grab(const input_type& input) {
 		const auto& result = grab_internal<std::decay_t<decltype(grab_from_tuple<tuple_idx, input_type>(input).get())>, grabbers...>(grab_from_tuple<tuple_idx, input_type>(input));
 		if constexpr (is_optional<typename std::decay_t<decltype(result)>>) {
 			if (result.has_value())
@@ -105,13 +113,11 @@ struct modular_curves_submember_input {
 	}
 };
 
-template<typename grabber_fnc>
+template<auto grabber_fnc>
 struct modular_curves_functional_input {
   private:
-	grabber_fnc grabber;
-
 	template<int tuple_idx, typename input_type>
-	inline auto grab_from_tuple(const input_type& input) const {
+	static inline auto grab_from_tuple(const input_type& input) {
 		if constexpr(tuple_idx < 0)
 			return std::cref(input);
 		else
@@ -119,19 +125,22 @@ struct modular_curves_functional_input {
 	}
 
   public:
-	modular_curves_functional_input(grabber_fnc grabber_) : grabber(std::move(grabber_)) {}
-
 	template<int tuple_idx, typename input_type>
-	inline float grab(const input_type& input) const {
+	static inline float grab(const input_type& input) {
 		if constexpr (std::is_pointer_v<std::remove_reference_t<input_type>>){
-			return grabber(*grab_from_tuple<tuple_idx, input_type>(input));
+			return grabber_fnc(*grab_from_tuple<tuple_idx, input_type>(input));
 		}
 		else {
-			return grabber(grab_from_tuple<tuple_idx, input_type>(input));
+			return grabber_fnc(grab_from_tuple<tuple_idx, input_type>(input));
 		}
 	}
 };
 
+//
+// Non-template modular curve helper structs, carrying per-curve data as well as data per-instance affected by modular curves.
+//
+
+// Do not instantiate this manually. The modular_curve_set struct will manage every use of this struct for you automatically.
 struct modular_curves_entry {
 	int curve_idx = -1;
 	::util::ParsedRandomFloatRange scaling_factor = ::util::UniformFloatRange(1.f);
@@ -139,57 +148,60 @@ struct modular_curves_entry {
 	bool wraparound = true;
 };
 
+//
+// This modular_curves_entry_instance contains data for any instances affected by modular curves.
+// On the example of Weapon Curves, each weapon instance would have one modular_curves_entry_instance.
+// Do not instance this struct manually, instead use modular_curves_set::create_instance()
+//
 struct modular_curves_entry_instance {
 	int seed_scaling_factor;
 	int seed_translation;
 };
 
-/*
- * output_enum must be a contiguous enum with a NUM_VALUES end
- * */
-template<typename input_type, typename output_enum, typename input_tuple_index, typename... input_grabbers>
-struct modular_curves {
+// Forward declaration of modular_curves_set, see explanation below
+template<const auto& definitions, typename input_type, typename output_enum, typename input_tuple_index, typename... input_grabbers>
+struct modular_curves_set;
+
+//
+// The modular_curves_definition contains the definition of one type of modular curves.
+// I.e., something like "Weapon Curves" should have ONE global constexpr instance of a modular_curves_definition struct.
+// It is in fact required that this instance is constexpr to be able to instance sets from it.
+// Do not instance this by hand, but use the make_modular_curve_definition helper template function,
+// or modular_curves_definition::derive_modular_curves_subset for derived defitions.
+// output_enum must be a contiguous enum with a NUM_VALUES end
+//
+template<typename input_type, typename output_enum, size_t output_names, typename input_tuple_index, typename... input_grabbers>
+struct modular_curves_definition {
   private:
-	static constexpr size_t num_inputs = sizeof...(input_grabbers);
+	// Friends for instantiation and access from the set.
+	template<typename, typename, size_t, typename, typename...>
+	friend struct modular_curves_definition;
+
+	template<const auto&, typename, typename, typename, typename...>
+	friend struct modular_curves_set;
+
+	template<const auto&>
+	friend inline auto make_modular_curve_set();
+
+	template<typename, typename output_enum_, size_t output_names_, typename... input_grabbers_>
+	friend constexpr auto make_modular_curve_definition(std::array<std::pair<const char*, output_enum_>, output_names_> outputs, std::pair<const char*, input_grabbers_>... inputs);
+
+	// Internal data
+	using this_definition_type = modular_curves_definition<input_type, output_enum, output_names, input_tuple_index, input_grabbers...>;
 	static constexpr size_t num_outputs = static_cast<size_t>(output_enum::NUM_VALUES);
 
-	SCP_unordered_map<SCP_string, output_enum, SCP_string_lcase_hash, SCP_string_lcase_equal_to> outputs;
+	std::array<std::pair<const char*, output_enum>, output_names> outputs;
 	std::tuple<std::pair<const char*, input_grabbers>...> inputs;
-	std::array<SCP_vector<std::pair<size_t, modular_curves_entry>>, num_outputs> curves; //Output -> List<(Input, curve_entry)>
-  public:
-	modular_curves(SCP_unordered_map<SCP_string, output_enum, SCP_string_lcase_hash, SCP_string_lcase_equal_to> outputs_, std::tuple<std::pair<const char*, input_grabbers>...> inputs_) : outputs(std::move(outputs_)), inputs(std::move(inputs_)), curves() {}
 
-	modular_curves_entry_instance create_instance() const {
-		return modular_curves_entry_instance{util::Random::next(), util::Random::next()};
+	// Constructors and creation helpers
+	constexpr modular_curves_definition(std::array<std::pair<const char*, output_enum>, output_names> outputs_, std::tuple<std::pair<const char*, input_grabbers>...> inputs_) : outputs(std::move(outputs_)), inputs(std::move(inputs_)) {}
+
+	template<const this_definition_type& curve_definition>
+	static inline auto make_modular_curve_set() {
+		return modular_curves_set<curve_definition, input_type, output_enum, input_tuple_index, input_grabbers...>{};
 	}
 
-  private:
-	inline std::pair<float, float> get_maybe_instanced_randoms(output_enum output, size_t input, const modular_curves_entry& curve_entry, const modular_curves_entry_instance* instance) const {
-		if (instance != nullptr) {
-			static constexpr std::array<std::array<uint32_t, num_outputs>, num_inputs> inout_seeds = []() constexpr {
-				std::array<std::array<uint32_t, num_outputs>, num_inputs> temp{};
-				for(size_t in = 0; in < num_inputs; in++) {
-					for(size_t out = 0; out < num_outputs; out++) {
-						//This isn't perfect, but absolutely sufficient to give each input-output combination different random values.
-						temp[in][out] = hash_fnv1a(hash_fnv1a(in) ^ out);
-					}
-				}
-				return temp;
-			}();
-
-			uint32_t seed = inout_seeds[input][static_cast<std::underlying_type_t<output_enum>>(output)] ^ curve_entry.curve_idx;
-
-			curve_entry.scaling_factor.seed(seed ^ instance->seed_scaling_factor);
-			curve_entry.translation.seed(seed ^ instance->seed_translation);
-
-			//This will yield consistent seeds (and thus random values) for the same tuples of input_idx-output_idx-curve_idx-instance_seed.
-			//if any of these four changes, the resulting value should be random with regard to the previous value.
-			//Furthermore, this seed generation is not commutative, so input 0 and output 1 will result in a different seed to input 1 and output 0
-		}
-
-		return {curve_entry.scaling_factor.next(), curve_entry.translation.next()};
-	}
-
+	//Helper function to for parsing
 	template<bool parsing, size_t... idx>
 	inline size_t get_input_idx_by_name(const char* input, std::index_sequence<idx...>) const {
 		size_t result = -1;
@@ -203,44 +215,8 @@ struct modular_curves {
 		return result;
 	}
 
-	template<size_t... idx>
-	inline float get_individual_input(size_t input_index, const input_type& input, std::index_sequence<idx...>) const {
-		float result = 1.f;
-		//GCC11+ and Clang will properly unroll this fold expression into a switch-case jumptable
-		bool matched_case = ((idx == input_index ? (result = std::get<idx>(inputs).second.template grab<std::tuple_element_t<idx, input_tuple_index>::value>(input)), true : false) || ...);
-		if (!matched_case) {
-			UNREACHABLE("Modular Curves requested Input %zu which has no grabber!", input_index);
-		}
-		return result;
-	}
-
-  public:
-	float get_output(output_enum output, const input_type& input, const modular_curves_entry_instance* instance = nullptr) const {
-		float result = 1.f;
-
-		for (const auto& [input_idx, curve_entry] : curves[static_cast<std::underlying_type_t<output_enum>>(output)]){
-			const auto& [scaling_factor, translation] = get_maybe_instanced_randoms(output, input_idx, curve_entry, instance);
-			const auto& curve = Curves[curve_entry.curve_idx];
-
-			float input_value = (get_individual_input(input_idx, input, std::index_sequence_for<input_grabbers...>{}) / scaling_factor) + translation;
-
-			if (curve_entry.wraparound) {
-				float final_x = curve.keyframes.back().pos.x;
-				input_value = std::fmod(input_value, final_x);
-			}
-
-			float output_value = curve.GetValue(input_value);
-			if (output_value < 0.f) {
-				output_value = 0.f;
-			}
-
-			result *= output_value;
-		}
-
-		return result;
-	}
-
-	void parse(const SCP_string& curve_type) {
+	// Parsing
+	void parse(std::array<SCP_vector<std::pair<size_t, modular_curves_entry>>, num_outputs>& curves, const SCP_string& curve_type) const {
 		while(optional_string(curve_type.c_str())) {
 			SCP_string input;
 			required_string("+Input:");
@@ -250,11 +226,19 @@ struct modular_curves {
 			SCP_string output;
 			required_string("+Output:");
 			stuff_string(output, F_NAME);
-			auto output_it = outputs.find(output);
-			if (output_it == outputs.end()){
+
+			bool found_output = false;
+			output_enum output_idx;
+			for (const auto& output_pair : outputs){
+				if (!stricmp(output_pair.first, output.c_str())){
+					found_output = true;
+					output_idx = output_pair.second;
+					break;
+				}
+			}
+			if (!found_output){
 				error_display(1, "Unexpected modular curve output %s!", output.c_str());
 			}
-			output_enum output_idx = output_it->second;
 
 			modular_curves_entry curve_entry;
 
@@ -284,13 +268,12 @@ struct modular_curves {
 		}
 	}
 
-	void add_curve(const SCP_string& input, output_enum output, modular_curves_entry curve_entry) {
+	void add_curve(std::array<SCP_vector<std::pair<size_t, modular_curves_entry>>, num_outputs>& curves, const SCP_string& input, output_enum output, modular_curves_entry curve_entry) const {
 		size_t input_idx = get_input_idx_by_name<false>(input.c_str(), std::index_sequence_for<input_grabbers...>{});
 		curves[static_cast<std::underlying_type_t<output_enum>>(output)].emplace_back(input_idx, std::move(curve_entry));
 	}
 
-private:
-	//Helper functions to compute the correct type for derived modular curved sets. Meant for unevaluated context (i.e. within a decltype) ONLY!
+	// Helper functions to compute the correct type for derived modular curved sets. Meant for unevaluated context (i.e. within a decltype) ONLY!
 	template<typename maybe_tuple, typename... tuple_additions>
 	static auto unevaluated_maybe_tuple_cat(const maybe_tuple& in, const tuple_additions&... adds) {
 		if constexpr(is_tuple<maybe_tuple>::value)
@@ -313,17 +296,18 @@ private:
 	}
 
 public:
-	template<typename additional_input_type, typename new_output_enum, typename... additional_input_grabbers>
-	auto derive_modular_curves_subset(SCP_unordered_map<SCP_string, new_output_enum, SCP_string_lcase_hash, SCP_string_lcase_equal_to> new_outputs, std::pair<const char*, additional_input_grabbers>... additional_inputs) {
+	template<typename additional_input_type, typename new_output_enum, size_t new_output_size, typename... additional_input_grabbers>
+	constexpr auto derive_modular_curves_subset(std::array<std::pair<const char*, new_output_enum>, new_output_size> new_outputs, std::pair<const char*, additional_input_grabbers>... additional_inputs) const {
 		using new_input_type = decltype(unevaluated_maybe_tuple_cat(std::declval<input_type>(), std::declval<additional_input_type>()));
 		using new_input_tuple_index = decltype(std::tuple_cat(
 				//Old tuple accessors, but if they were -1 (i.e. no tuple) set them to 0 (i.e. first element)
 				unevaluated_tuple_of_input_idx_least_0(std::index_sequence_for<input_grabbers...>()),
 				//New tuple accessors, highest observed one + 1
 				std::tuple<std::integral_constant<std::conditional_t<true, int, additional_input_grabbers>, find_lowest_tuple_integral_constant<input_tuple_index>(std::index_sequence_for<input_grabbers...>()) + 1>...>())); //This "seemingly unnecessary" conditional is required to be able to unpack the parameter pack over the additional_input_grabbers and get a tuple type of the identical length
-		return modular_curves<
+		return modular_curves_definition<
 				new_input_type,
 				new_output_enum,
+				new_output_size,
 				new_input_tuple_index,
 				input_grabbers..., additional_input_grabbers...>(
 				std::move(new_outputs), std::tuple_cat(inputs, std::make_tuple(std::move(additional_inputs)...))
@@ -331,13 +315,121 @@ public:
 	}
 };
 
-template<typename input_type, typename output_enum, typename... input_grabbers>
-constexpr auto make_modular_curves(SCP_unordered_map<SCP_string, output_enum, SCP_string_lcase_hash, SCP_string_lcase_equal_to> outputs, std::pair<const char*, input_grabbers>... inputs) {
-	return modular_curves<
-	        input_type,
+//
+// A modular_curves_set contains all data that is required at runtime to store the parsed table.
+// It itself contains no static parsing data, only a compiletime reference to the curve definitions (which have this data)
+// On the example of weapon curves, one instance of a modular_curves_set should exist for every weapon class.
+// Do not manually instance this struct, instead use the make_modular_curve_set<definition>() helper.
+//
+template<const auto& definitions, typename input_type, typename output_enum, typename input_tuple_index, typename... input_grabbers>
+struct modular_curves_set {
+private:
+	// Friends to allow creation from curve definitions
+	template<typename, typename, size_t, typename, typename...>
+	friend struct modular_curves_definition;
+
+	// Internal data
+	static constexpr size_t num_inputs = sizeof...(input_grabbers);
+	static constexpr size_t num_outputs = static_cast<size_t>(output_enum::NUM_VALUES);
+
+	using input_grabber_tuple = std::tuple<input_grabbers...>;
+	std::array<SCP_vector<std::pair<size_t, modular_curves_entry>>, num_outputs> curves; //Output -> List<(Input, curve_entry)>
+
+	constexpr modular_curves_set() : curves() {}
+public:
+	// Used to create an instance for any single thing affected by modular curves. Note that having an instance is purely optional
+	modular_curves_entry_instance create_instance() const {
+		return modular_curves_entry_instance{util::Random::next(), util::Random::next()};
+	}
+
+private:
+	// Internal methods for computing the curve result
+	inline std::pair<float, float> get_maybe_instanced_randoms(output_enum output, size_t input, const modular_curves_entry& curve_entry, const modular_curves_entry_instance* instance) const {
+		if (instance != nullptr) {
+			static constexpr std::array<std::array<uint32_t, num_outputs>, num_inputs> inout_seeds = []() constexpr {
+				std::array<std::array<uint32_t, num_outputs>, num_inputs> temp{};
+				for(size_t in = 0; in < num_inputs; in++) {
+					for(size_t out = 0; out < num_outputs; out++) {
+						//This isn't perfect, but absolutely sufficient to give each input-output combination different random values.
+						temp[in][out] = hash_fnv1a(hash_fnv1a(in) ^ out);
+					}
+				}
+				return temp;
+			}();
+
+			uint32_t seed = inout_seeds[input][static_cast<std::underlying_type_t<output_enum>>(output)] ^ curve_entry.curve_idx;
+
+			curve_entry.scaling_factor.seed(seed ^ instance->seed_scaling_factor);
+			curve_entry.translation.seed(seed ^ instance->seed_translation);
+
+			//This will yield consistent seeds (and thus random values) for the same tuples of input_idx-output_idx-curve_idx-instance_seed.
+			//if any of these four changes, the resulting value should be random with regard to the previous value.
+			//Furthermore, this seed generation is not commutative, so input 0 and output 1 will result in a different seed to input 1 and output 0
+		}
+
+		return {curve_entry.scaling_factor.next(), curve_entry.translation.next()};
+	}
+
+	template<size_t... idx>
+	inline float get_individual_input(size_t input_index, const input_type& input, std::index_sequence<idx...>) const {
+		float result = 1.f;
+		//GCC11+ and Clang will properly unroll this fold expression into a switch-case jumptable
+		bool matched_case = ((idx == input_index ? (result = std::tuple_element_t<idx, input_grabber_tuple>::template grab<std::tuple_element_t<idx, input_tuple_index>::value>(input)), true : false) || ...);
+		if (!matched_case) {
+			UNREACHABLE("Modular Curves requested Input %zu which has no grabber!", input_index);
+		}
+		return result;
+	}
+
+public:
+	float get_output(output_enum output, const input_type& input, const modular_curves_entry_instance* instance = nullptr) const {
+		float result = 1.f;
+
+		for (const auto& [input_idx, curve_entry] : curves[static_cast<std::underlying_type_t<output_enum>>(output)]){
+			const auto& [scaling_factor, translation] = get_maybe_instanced_randoms(output, input_idx, curve_entry, instance);
+			const auto& curve = Curves[curve_entry.curve_idx];
+
+			float input_value = (get_individual_input(input_idx, input, std::index_sequence_for<input_grabbers...>{}) / scaling_factor) + translation;
+
+			if (curve_entry.wraparound) {
+				float final_x = curve.keyframes.back().pos.x;
+				input_value = std::fmod(input_value, final_x);
+			}
+
+			result *= std::max(curve.GetValue(input_value), 0.0f);
+		}
+
+		return result;
+	}
+
+	inline void parse(const SCP_string& curve_type) {
+		definitions.parse(curves, curve_type);
+	}
+
+	// Use add_curve to programmatically add a curve as if it had been tabled.
+	inline void add_curve(const SCP_string& input, output_enum output, modular_curves_entry curve_entry) {
+		definitions.add_curve(curves, input, output, std::move(curve_entry));
+	}
+};
+
+//
+// Helper functions to instance the modular curve structs. Helper functions are used because function template argument deduction is slightly more robust than CTAD, resulting in less verbose calls
+//
+
+template<typename input_type, typename output_enum, size_t output_names, typename... input_grabbers>
+constexpr auto make_modular_curve_definition(std::array<std::pair<const char*, output_enum>, output_names> outputs, std::pair<const char*, input_grabbers>... inputs) {
+	return modular_curves_definition<
+			input_type,
 			output_enum,
+			output_names,
 			std::tuple<std::integral_constant<std::conditional_t<true, int, input_grabbers>, -1>...>, //This "seemingly unnecessary" conditional is required to be able to unpack the parameter pack over the input_grabbers and get a tuple type of the identical length
 			input_grabbers...>(
-		std::move(outputs), std::make_tuple(std::move(inputs)...)
+			std::move(outputs), std::make_tuple(std::move(inputs)...)
 	);
+}
+
+template<const auto& curve_definition>
+inline auto make_modular_curve_set() {
+	using modular_curves_definition = std::decay_t<decltype(curve_definition)>;
+	return modular_curves_definition::template make_modular_curve_set<curve_definition>();
 }

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -320,7 +320,7 @@ public:
 				//Old tuple accessors, but if they were -1 (i.e. no tuple) set them to 0 (i.e. first element)
 				unevaluated_tuple_of_input_idx_least_0(std::index_sequence_for<input_grabbers...>()),
 				//New tuple accessors, highest observed one + 1
-				std::tuple<std::integral_constant<std::conditional_t<true, int, input_grabbers>, find_lowest_tuple_integral_constant<input_tuple_index>(std::index_sequence_for<input_grabbers...>()) + 1>...>())); //This "seemingly unnecessary" conditional is required to be able to unpack the parameter pack over the input_grabbers and get a tuple type of the identical length
+				std::tuple<std::integral_constant<std::conditional_t<true, int, additional_input_grabbers>, find_lowest_tuple_integral_constant<input_tuple_index>(std::index_sequence_for<input_grabbers...>()) + 1>...>())); //This "seemingly unnecessary" conditional is required to be able to unpack the parameter pack over the additional_input_grabbers and get a tuple type of the identical length
 		return modular_curves<
 				new_input_type,
 				new_output_enum,

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -1,0 +1,220 @@
+#pragma once
+
+#include "utils/RandomRange.h"
+#include "math/curve.h"
+
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+template<typename>   constexpr bool is_optional = false;
+template<typename T> constexpr bool is_optional<std::optional<T>> = true;
+template<> 			 constexpr bool is_optional<std::nullopt_t> = true;
+
+template<auto... grabbers>
+struct modular_curves_submember_input {
+  private:
+	template<typename input_type, auto grabber>
+	inline auto grab_part(const input_type& input) const {
+		//Pointer to member type, i.e. for submember access
+		if constexpr (std::is_member_object_pointer_v<decltype(grabber)>) {
+			if constexpr (std::is_pointer_v<std::remove_reference_t<input_type>>)
+				return std::cref(input->*grabber);
+			else
+				return std::cref(input.*grabber);
+		}
+		//Pointer to static variable, i.e. used to index into things.
+		else if constexpr (std::is_pointer_v<decltype(grabber)>) {
+			static_assert(std::is_integral_v<std::remove_cv_t<std::remove_reference_t<input_type>>>, "Can only index into array from an integral input");
+			using indexing_type = std::decay_t<decltype((*grabber)[input])>;
+			if (input >= 0)
+				return std::optional<std::reference_wrapper<const indexing_type>>{ std::cref((*grabber)[input]) };
+			else
+				return std::optional<std::reference_wrapper<const indexing_type>>(std::nullopt);
+		}
+		//Integer, used to index into tuples. Should be rarely used by actual users, but is required to do child-types.
+		else if constexpr (std::is_integral_v<decltype(grabber)>) {
+			if constexpr (std::is_pointer_v<std::remove_reference_t<input_type>>)
+				return std::cref(std::get<grabber>(*input));
+			else
+				return std::cref(std::get<grabber>(input));
+		}
+		else {
+			static_assert(!std::is_same_v<input_type, input_type>, "Unknown grabber type in modular curves");
+		}
+	}
+
+	template<typename input_type, auto grabber, auto... other_grabbers>
+	inline auto grab_internal(std::reference_wrapper<const input_type> input) const {
+		//If we're down to one grabber only, return it
+		if constexpr (sizeof...(other_grabbers) == 0){
+			return grab_part<input_type, grabber>(input.get());
+		}
+		//Otherwise, use the current grabber, and forward the result to the next grabber
+		else {
+			const auto& current_access = grab_part<input_type, grabber>(input.get());
+			//If the current grabber isn't guaranteed to succeed, check for completion first
+			if constexpr (is_optional<std::decay_t<decltype(current_access)>>) {
+				using lower_return_type = decltype(grab_internal<std::decay_t<decltype((*current_access).get())>, other_grabbers...>(*current_access));
+				using return_type = typename std::conditional_t<is_optional<std::decay_t<lower_return_type>>, lower_return_type, std::optional<lower_return_type>>;
+				//If we're already nullopt (i.e. this array access failed) return early
+				if (current_access.has_value()) {
+					//Now, it's possible that lower acceses _also_ produce optionals. In this case, we need to forward the lower result, not re-wrap it.
+					if constexpr (is_optional<std::decay_t<lower_return_type>>) {
+						return grab_internal<std::decay_t<decltype((*current_access).get())>, other_grabbers...>(*current_access);
+					}
+					else{
+						return return_type(grab_internal<std::decay_t<decltype((*current_access).get())>, other_grabbers...>(*current_access));
+					}
+				}
+				else
+				    return return_type(std::nullopt);
+			}
+			//Otherwise just send it on to the next grabber
+			else {
+				return grab_internal<std::decay_t<decltype(current_access.get())>, other_grabbers...>(current_access.get());
+			}
+		}
+	}
+
+  public:
+	template<typename input_type>
+	inline float grab(const input_type& input) const {
+		const auto& result = grab_internal<input_type, grabbers...>(std::cref(input));
+		if constexpr (is_optional<typename std::decay_t<decltype(result)>>) {
+			if (result.has_value())
+				return result->get();
+			else
+				return 1.0f;
+		}
+		else {
+			return result.get();
+		}
+	}
+};
+
+template<typename grabber_fnc>
+struct modular_curves_functional_input {
+  private:
+	grabber_fnc grabber;
+
+  public:
+	modular_curves_functional_input(grabber_fnc grabber_) : grabber(std::move(grabber_)) {}
+
+	template<typename input_type>
+	inline float grab(const input_type& input) const {
+		if constexpr (std::is_pointer_v<std::remove_reference_t<input_type>>){
+			return grabber(*input);
+		}
+		else {
+			return grabber(input);
+		}
+	}
+};
+
+struct modular_curves_entry {
+	int curve_idx = -1;
+	//TODO update to parsed
+	::util::UniformFloatRange scaling_factor = ::util::UniformFloatRange(1.f);
+	::util::UniformFloatRange translation = ::util::UniformFloatRange(0.f);
+	bool wraparound = true;
+};
+
+struct modular_curves_entry_instance {
+	float scaling_factor;
+	float translation;
+
+};
+
+template<typename input_type, typename output_enum, typename... input_grabbers>
+struct modular_curves {
+  private:
+	SCP_unordered_map<SCP_string, output_enum> outputs;
+	std::tuple<std::pair<const char*, input_grabbers>...> inputs;
+	SCP_unordered_map<output_enum, SCP_vector<std::pair<size_t, modular_curves_entry>>> curves; //Output -> List<(Input, curve_entry)>
+
+  public:
+	modular_curves(SCP_unordered_map<SCP_string, output_enum> outputs_, std::tuple<std::pair<const char*, input_grabbers>...> inputs_) : outputs(std::move(outputs_)), inputs(std::move(inputs_)), curves() {}
+
+	using instance_data = SCP_unordered_map<output_enum, SCP_unordered_map<size_t, modular_curves_entry_instance>>;
+	instance_data create_instance() const {
+		instance_data instance;
+		for (const auto& [output, curve_pair] : curves) {
+			auto& instance_output_map = instance[output];
+			for (const auto& [input, curve_entry] : curve_pair) {
+				instance_output_map.emplace(input, modular_curves_entry_instance{ curve_entry.scaling_factor.next(), curve_entry.translation.next() });
+			}
+		}
+		return instance;
+	}
+
+  private:
+	inline std::pair<float, float> get_instance_data(output_enum output, size_t input, const modular_curves_entry& curve_entry, const instance_data* instance) const {
+		std::pair<float, float> data;
+		bool has_data = false;
+		if (instance != nullptr) {
+			auto current_instance = instance->find(output);
+			if (current_instance != instance->end()) {
+				auto current_curve = current_instance->second.find(input);
+				if (current_curve != current_instance->second.end()) {
+					data.first = current_curve->second.scaling_factor;
+					data.second = current_curve->second.translation;
+					has_data = true;
+				}
+			}
+		}
+		if (!has_data) {
+			data.first = curve_entry.scaling_factor.next();
+			data.second = curve_entry.translation.next();
+		}
+		return data;
+	}
+
+	template<size_t... idx>
+	inline float get_individual_input(size_t input_index, const input_type& input, std::index_sequence<idx...>) const {
+		float result = 1.f;
+		//GCC11+ and Clang will properly unroll this fold expression into a switch-case jumptable
+		bool matched_case = ((idx == input_index ? (result = std::get<idx>(inputs).second.grab(input)), true : false) || ...);
+		if (!matched_case) {
+			UNREACHABLE("Modular Curves requested Input %zu which has no grabber!", input_index);
+		}
+		return result;
+	}
+
+  public:
+	float get_output(output_enum output, const input_type& input, const instance_data* instance = nullptr) const {
+		float result = 1.f;
+
+		auto output_curves = curves.find(output);
+		if (output_curves == curves.end())
+			return result;
+
+		for (const auto& [input_idx, curve_entry] : output_curves->second){
+			const auto& [scaling_factor, translation] = get_instance_data(output, input_idx, curve_entry, instance);
+			const auto& curve = Curves[curve_entry.curve_idx];
+
+			float input_value = (get_individual_input(input_idx, input, std::index_sequence_for<input_grabbers...>{}) / scaling_factor) + translation;
+
+			if (curve_entry.wraparound) {
+				float final_x = curve.keyframes.back().pos.x;
+				input_value = std::fmod(input_value, final_x);
+			}
+
+			float output_value = curve.GetValue(input_value);
+			if (output_value < 0.f) {
+				output_value = 0.f;
+			}
+
+			result *= output_value;
+		}
+
+		return result;
+	}
+};
+
+template<typename input_type, typename output_enum, typename... input_grabbers>
+constexpr auto make_modular_curves(SCP_unordered_map<SCP_string, output_enum> outputs, std::pair<const char*, input_grabbers>... inputs) {
+	return modular_curves<input_type, output_enum, input_grabbers...>(
+		std::move(outputs), std::make_tuple(std::move(inputs)...)
+	);
+}

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -126,12 +126,15 @@ struct modular_curves_entry_instance {
 
 };
 
+/*
+ * output_enum must be a contiguous enum with a NUM_VALUES end
+ * */
 template<typename input_type, typename output_enum, typename... input_grabbers>
 struct modular_curves {
   private:
 	SCP_unordered_map<SCP_string, output_enum> outputs;
 	std::tuple<std::pair<const char*, input_grabbers>...> inputs;
-	SCP_unordered_map<output_enum, SCP_vector<std::pair<size_t, modular_curves_entry>>> curves; //Output -> List<(Input, curve_entry)>
+	std::array<SCP_vector<std::pair<size_t, modular_curves_entry>>, static_cast<std::underlying_type_t<output_enum>>(output_enum::NUM_VALUES)> curves; //Output -> List<(Input, curve_entry)>
 
   public:
 	modular_curves(SCP_unordered_map<SCP_string, output_enum> outputs_, std::tuple<std::pair<const char*, input_grabbers>...> inputs_) : outputs(std::move(outputs_)), inputs(std::move(inputs_)), curves() {}
@@ -185,11 +188,7 @@ struct modular_curves {
 	float get_output(output_enum output, const input_type& input, const instance_data* instance = nullptr) const {
 		float result = 1.f;
 
-		auto output_curves = curves.find(output);
-		if (output_curves == curves.end())
-			return result;
-
-		for (const auto& [input_idx, curve_entry] : output_curves->second){
+		for (const auto& [input_idx, curve_entry] : curves[static_cast<std::underlying_type_t<output_enum>>(output)]){
 			const auto& [scaling_factor, translation] = get_instance_data(output, input_idx, curve_entry, instance);
 			const auto& curve = Curves[curve_entry.curve_idx];
 

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -17,6 +17,7 @@
 //
 #include "globalincs/globals.h"
 #include "model/model.h"
+#include "utils/modular_curves.h"
 
 // prototypes
 class object;
@@ -218,7 +219,9 @@ typedef struct beam {
 	bool rotates;					// type 5s only, determines whether it rotates
 	float type5_rot_speed;          // how fast it rotates if it does
 
-	WeaponState weapon_state;  
+	WeaponState weapon_state;
+
+	modular_curves_entry_instance modular_curves_instance;
 } beam;
 
 extern std::array<beam, MAX_BEAMS> Beams;				// all beams


### PR DESCRIPTION
Adds modular curve framework.
Implements a few samples of modular curves in- and outputs.
Replaces the original `damage_curve_idx` with a modular curve set for hits, while preserving legacy table parsing.